### PR TITLE
✨ Feature: 회원 관련 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.lmax:disruptor:3.4.4'
 
+    // lang
+    implementation 'org.apache.commons:commons-lang3:3.16.0'
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/AccountController.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/AccountController.java
@@ -1,9 +1,11 @@
 package com.pop.backend.domain.account.controller;
 
+import com.pop.backend.domain.account.controller.request.AccountDeleteFollowArtistRequest;
 import com.pop.backend.domain.account.controller.request.AccountUpdateImageRequest;
 import com.pop.backend.domain.account.controller.request.AccountUpdateNicknameRequest;
 import com.pop.backend.domain.account.controller.response.AccountGetDetailResponse;
 import com.pop.backend.domain.account.controller.response.AccountGetSimpleResponse;
+import com.pop.backend.domain.account.controller.response.FollowArtistGetListResponse;
 import com.pop.backend.domain.account.service.AccountService;
 import com.pop.backend.global.type.CookieNames;
 import com.pop.backend.global.utils.CookieManager;
@@ -63,6 +65,17 @@ public class AccountController {
   public void updateAccountImage(@RequestBody AccountUpdateImageRequest imageRequest,
       @AuthenticationPrincipal String email) {
     accountService.updateAccountImage(email, imageRequest.profileImage());
+  }
+
+  @GetMapping("/me/artists")
+  public FollowArtistGetListResponse getFollowArtists(@AuthenticationPrincipal String email) {
+    return accountService.getFollowArtists(email);
+  }
+
+  @DeleteMapping("/me/artists")
+  public void deleteFollowArtists(@RequestBody AccountDeleteFollowArtistRequest deleteFollowArtistRequest,
+      @AuthenticationPrincipal String email) {
+    accountService.deleteFollowArtists(email, deleteFollowArtistRequest.artists());
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/AccountController.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/AccountController.java
@@ -1,10 +1,14 @@
 package com.pop.backend.domain.account.controller;
 
+import com.pop.backend.domain.account.service.AccountService;
+import com.pop.backend.global.type.CookieNames;
+import com.pop.backend.global.utils.CookieManager;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,13 +20,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
 
   private static final String REDIRECT_URL = "/oauth2/authorization/";
-  private final RedirectStrategy redirectStrategy;
+  private final AccountService accountService;
 
   @GetMapping("/signin/{provider}")
-  public void redirectOAuth2LoginPage(@PathVariable String provider,
-      HttpServletRequest request, HttpServletResponse response) throws IOException {
+  public void redirectOAuth2LoginPage(@PathVariable String provider, HttpServletResponse response) throws IOException {
     String redirectUrl = REDIRECT_URL + provider;
-    redirectStrategy.sendRedirect(request, response, redirectUrl);
+    response.sendRedirect(redirectUrl);
+  }
+
+  @DeleteMapping("/withdraw")
+  public void withDrawAccount(@AuthenticationPrincipal String email,
+      HttpServletRequest request, HttpServletResponse response) {
+    String refreshToken = CookieManager.getCookie(CookieNames.REFRESH_TOKEN.getName(), request);
+    accountService.withDrawAccount(email, refreshToken);
+    CookieManager.removeCookie(CookieNames.ACCESS_TOKEN.getName(), response);
+    CookieManager.removeCookie(CookieNames.REFRESH_TOKEN.getName(), response);
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/AccountController.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/AccountController.java
@@ -1,0 +1,28 @@
+package com.pop.backend.domain.account.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/accounts")
+@RequiredArgsConstructor
+public class AccountController {
+
+  private static final String REDIRECT_URL = "/oauth2/authorization/";
+  private final RedirectStrategy redirectStrategy;
+
+  @GetMapping("/signin/{provider}")
+  public void redirectOAuth2LoginPage(@PathVariable String provider,
+      HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String redirectUrl = REDIRECT_URL + provider;
+    redirectStrategy.sendRedirect(request, response, redirectUrl);
+  }
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/AccountController.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/AccountController.java
@@ -1,5 +1,9 @@
 package com.pop.backend.domain.account.controller;
 
+import com.pop.backend.domain.account.controller.request.AccountUpdateImageRequest;
+import com.pop.backend.domain.account.controller.request.AccountUpdateNicknameRequest;
+import com.pop.backend.domain.account.controller.response.AccountGetDetailResponse;
+import com.pop.backend.domain.account.controller.response.AccountGetSimpleResponse;
 import com.pop.backend.domain.account.service.AccountService;
 import com.pop.backend.global.type.CookieNames;
 import com.pop.backend.global.utils.CookieManager;
@@ -10,7 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,12 +35,34 @@ public class AccountController {
   }
 
   @DeleteMapping("/withdraw")
-  public void withDrawAccount(@AuthenticationPrincipal String email,
+  public void removeAccountWithdraw(@AuthenticationPrincipal String email,
       HttpServletRequest request, HttpServletResponse response) {
     String refreshToken = CookieManager.getCookie(CookieNames.REFRESH_TOKEN.getName(), request);
     accountService.withDrawAccount(email, refreshToken);
     CookieManager.removeCookie(CookieNames.ACCESS_TOKEN.getName(), response);
     CookieManager.removeCookie(CookieNames.REFRESH_TOKEN.getName(), response);
+  }
+
+  @GetMapping("/me/profile")
+  public AccountGetSimpleResponse getAccountSimpleProfile(@AuthenticationPrincipal String email) {
+    return accountService.getAccountSimpleInfo(email);
+  }
+
+  @GetMapping("/me")
+  public AccountGetDetailResponse getAccountDetailProfile(@AuthenticationPrincipal String email) {
+    return accountService.getAccountDetailInfo(email);
+  }
+
+  @PatchMapping("/me/nickname")
+  public void updateAccountNickname(@RequestBody AccountUpdateNicknameRequest nicknameRequest,
+      @AuthenticationPrincipal String email) {
+    accountService.updateAccountNickname(email, nicknameRequest.nickname());
+  }
+
+  @PatchMapping("/me/image")
+  public void updateAccountImage(@RequestBody AccountUpdateImageRequest imageRequest,
+      @AuthenticationPrincipal String email) {
+    accountService.updateAccountImage(email, imageRequest.profileImage());
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/request/AccountDeleteFollowArtistRequest.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/request/AccountDeleteFollowArtistRequest.java
@@ -1,0 +1,15 @@
+package com.pop.backend.domain.account.controller.request;
+
+import java.util.List;
+
+public record AccountDeleteFollowArtistRequest(
+    List<FollowArtistToken> artists
+) {
+
+  public record FollowArtistToken(
+      String token
+  ) {
+
+  }
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/request/AccountUpdateImageRequest.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/request/AccountUpdateImageRequest.java
@@ -1,0 +1,10 @@
+package com.pop.backend.domain.account.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AccountUpdateImageRequest(
+    @JsonProperty("profile_image")
+    String profileImage
+) {
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/request/AccountUpdateNicknameRequest.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/request/AccountUpdateNicknameRequest.java
@@ -1,0 +1,7 @@
+package com.pop.backend.domain.account.controller.request;
+
+public record AccountUpdateNicknameRequest(
+    String nickname
+) {
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/response/AccountGetDetailResponse.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/response/AccountGetDetailResponse.java
@@ -1,0 +1,18 @@
+package com.pop.backend.domain.account.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pop.backend.domain.account.persistence.Account;
+
+public record AccountGetDetailResponse(
+    String nickname,
+
+    @JsonProperty("profile_image")
+    String profileImage,
+
+    String email
+) {
+
+  public static AccountGetDetailResponse of(Account account) {
+    return new AccountGetDetailResponse(account.getNickname(), account.getProfileImage(), account.getEmail());
+  }
+}

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/response/AccountGetSimpleResponse.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/response/AccountGetSimpleResponse.java
@@ -1,0 +1,17 @@
+package com.pop.backend.domain.account.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pop.backend.domain.account.persistence.Account;
+
+public record AccountGetSimpleResponse(
+    String nickname,
+
+    @JsonProperty("profile_image")
+    String profileImage
+) {
+
+  public static AccountGetSimpleResponse of(Account account) {
+    return new AccountGetSimpleResponse(account.getNickname(), account.getProfileImage());
+  }
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/account/controller/response/FollowArtistGetListResponse.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/controller/response/FollowArtistGetListResponse.java
@@ -1,0 +1,15 @@
+package com.pop.backend.domain.account.controller.response;
+
+import com.pop.backend.domain.artist.persistence.Artist;
+import com.pop.backend.global.type.ArtistResponse;
+import java.util.List;
+
+public record FollowArtistGetListResponse(
+    List<ArtistResponse> artists
+) {
+
+  public static FollowArtistGetListResponse convert(List<Artist> artists) {
+    List<ArtistResponse> artistResponses = artists.stream().map(ArtistResponse::convert).toList();
+    return new FollowArtistGetListResponse(artistResponses);
+  }
+}

--- a/backend/src/main/java/com/pop/backend/domain/account/persistence/Account.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/persistence/Account.java
@@ -6,6 +6,7 @@ import com.pop.backend.global.type.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -30,14 +31,14 @@ public class Account extends BaseEntity {
   @Enumerated(value = EnumType.STRING)
   private ProviderType providerType = ProviderType.LOCAL;
 
-  private String providerId;
+  private Long providerId;
 
   @Default
   @Enumerated(value = EnumType.STRING)
   private Role role = Role.USER;
 
   private Account(String email, String password, String nickname, String profileImage, ProviderType providerType,
-      String providerId, Role role) {
+      Long providerId, Role role) {
     this.email = email;
     this.password = password;
     this.nickname = nickname;
@@ -49,6 +50,10 @@ public class Account extends BaseEntity {
 
   public String getRoleKey() {
     return role.getKey();
+  }
+
+  public void updateDeleteDate() {
+    this.setDelete_date(LocalDateTime.now());
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/persistence/Account.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/persistence/Account.java
@@ -6,7 +6,6 @@ import com.pop.backend.global.type.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -50,10 +49,6 @@ public class Account extends BaseEntity {
 
   public String getRoleKey() {
     return role.getKey();
-  }
-
-  public void updateDeleteDate() {
-    this.setDelete_date(LocalDateTime.now());
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/persistence/Account.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/persistence/Account.java
@@ -51,4 +51,12 @@ public class Account extends BaseEntity {
     return role.getKey();
   }
 
+  public void updateNickname(String nickname) {
+    this.nickname = nickname;
+  }
+
+  public void updateProfileImage(String profileImage) {
+    this.profileImage = profileImage;
+  }
+
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/persistence/repository/QAccountRepository.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/persistence/repository/QAccountRepository.java
@@ -1,9 +1,12 @@
 package com.pop.backend.domain.account.persistence.repository;
 
 import com.pop.backend.domain.account.persistence.type.Role;
+import java.util.List;
 
 public interface QAccountRepository {
 
   boolean existsAdminByEmailAndRole(String email, Role role);
+
+  void removeFollowArtists(String email, List<String> token);
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/persistence/repository/QAccountRepositoryImpl.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/persistence/repository/QAccountRepositoryImpl.java
@@ -2,9 +2,13 @@ package com.pop.backend.domain.account.persistence.repository;
 
 
 import static com.pop.backend.domain.account.persistence.QAccount.account;
+import static com.pop.backend.domain.artist.persistence.QArtist.artist;
+import static com.pop.backend.domain.artist.persistence.QFollowArtist.followArtist;
 
 import com.pop.backend.domain.account.persistence.type.Role;
+import com.pop.backend.domain.artist.persistence.Artist;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,8 +24,22 @@ public class QAccountRepositoryImpl implements QAccountRepository {
     return Objects.nonNull(queryFactory.selectFrom(account)
                                        .where(
                                            account.email.eq(email).and(account.role.eq(role))
-                                       )
-                                       .fetchOne());
+                                       ).fetchOne());
+  }
+
+  @Override
+  public void removeFollowArtists(String email, List<String> tokens) {
+    List<Artist> artists = queryFactory.selectFrom(artist)
+                                       .where(artist.token.in(tokens))
+                                       .fetch();
+    if (artists.isEmpty()) {
+      return;
+    }
+    queryFactory.delete(followArtist)
+                .where(
+                    followArtist.artist.in(artists)
+                                       .and(followArtist.account.email.eq(email))
+                ).execute();
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/service/AccountService.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/service/AccountService.java
@@ -1,5 +1,7 @@
 package com.pop.backend.domain.account.service;
 
+import com.pop.backend.domain.account.controller.response.AccountGetDetailResponse;
+import com.pop.backend.domain.account.controller.response.AccountGetSimpleResponse;
 import com.pop.backend.domain.account.persistence.Account;
 import com.pop.backend.domain.account.persistence.repository.AccountRepository;
 import com.pop.backend.global.exception.type.EntityException;
@@ -28,7 +30,36 @@ public class AccountService {
     account.updateDeleteDate();
     accountRepository.save(account);
   }
-  
+
+  @Transactional(readOnly = true)
+  public AccountGetSimpleResponse getAccountSimpleInfo(String email) {
+    Account account = findAccountByEmail(email);
+    return AccountGetSimpleResponse.of(account);
+  }
+
+  @Transactional(readOnly = true)
+  public AccountGetDetailResponse getAccountDetailInfo(String email) {
+    Account account = findAccountByEmail(email);
+    return AccountGetDetailResponse.of(account);
+  }
+
+  @Transactional
+  public void updateAccountNickname(String email, String nickname) {
+    Account account = findAccountByEmail(email);
+    account.updateNickname(nickname);
+    accountRepository.save(account);
+  }
+
+  @Transactional
+  public void updateAccountImage(String email, String profileImage) {
+    Account account = findAccountByEmail(email);
+    // s3 연동이 필요.
+    // 들어온 이미지 파일을 -> s3에 업로드
+    // s3에서 응답되는 파일을 저장
+    account.updateProfileImage(profileImage);
+    accountRepository.save(account);
+  }
+
   private Account findAccountByEmail(String email) {
     return accountRepository.findByEmail(email)
                             .orElseThrow(() -> new EntityException(ServiceErrorCode.USER_NOT_FOUND));

--- a/backend/src/main/java/com/pop/backend/domain/account/service/AccountService.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/service/AccountService.java
@@ -3,6 +3,7 @@ package com.pop.backend.domain.account.service;
 import com.pop.backend.domain.account.persistence.Account;
 import com.pop.backend.domain.account.persistence.repository.AccountRepository;
 import com.pop.backend.global.exception.type.EntityException;
+import com.pop.backend.global.exception.type.SecurityException;
 import com.pop.backend.global.exception.type.ServiceErrorCode;
 import com.pop.backend.global.jwt.TokenService;
 import com.pop.backend.global.security.service.OAuth2UnlinkManager;
@@ -18,19 +19,36 @@ public class AccountService {
   private final TokenService tokenService;
   private final OAuth2UnlinkManager unlinkManager;
 
-  // 내일 좀 더 구체적으로 로직을 구성할 것
   @Transactional
   public void withDrawAccount(String email, String refreshToken) {
-    // 0. User Entity 조회
-    Account account = accountRepository.findByEmail(email)
-                                       .orElseThrow(() -> new EntityException(ServiceErrorCode.USER_NOT_FOUND));
-    // 1. 연결끊기
-    unlinkManager.unlink(account.getProviderType(), String.valueOf(account.getProviderId()));
-    // 2. redis, httpsession 토큰 삭제
+    Account account = findAccountByEmail(email);
+    validateAccountStatus(account);
+    unlinkAccount(account);
     tokenService.removeRefreshToken(refreshToken);
-    // 3. Repository 에서 삭제 -> Soft Delete
     account.updateDeleteDate();
     accountRepository.save(account);
+  }
+  
+  private Account findAccountByEmail(String email) {
+    return accountRepository.findByEmail(email)
+                            .orElseThrow(() -> new EntityException(ServiceErrorCode.USER_NOT_FOUND));
+  }
+
+  private void validateAccountStatus(Account account) {
+    if (account.isDeleted()) {
+      throw new EntityException(ServiceErrorCode.ACCOUNT_ALREADY_DELETED);
+    }
+  }
+
+
+  private void unlinkAccount(Account account) {
+    try {
+      if (!unlinkManager.unlink(account.getProviderType(), String.valueOf(account.getProviderId()))) {
+        throw new SecurityException(ServiceErrorCode.UNLINK_FAIL);
+      }
+    } catch (Exception e) {
+      throw new SecurityException(ServiceErrorCode.UNLINK_FAIL);
+    }
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/account/service/AccountService.java
+++ b/backend/src/main/java/com/pop/backend/domain/account/service/AccountService.java
@@ -1,0 +1,36 @@
+package com.pop.backend.domain.account.service;
+
+import com.pop.backend.domain.account.persistence.Account;
+import com.pop.backend.domain.account.persistence.repository.AccountRepository;
+import com.pop.backend.global.exception.type.EntityException;
+import com.pop.backend.global.exception.type.ServiceErrorCode;
+import com.pop.backend.global.jwt.TokenService;
+import com.pop.backend.global.security.service.OAuth2UnlinkManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+  private final AccountRepository accountRepository;
+  private final TokenService tokenService;
+  private final OAuth2UnlinkManager unlinkManager;
+
+  // 내일 좀 더 구체적으로 로직을 구성할 것
+  @Transactional
+  public void withDrawAccount(String email, String refreshToken) {
+    // 0. User Entity 조회
+    Account account = accountRepository.findByEmail(email)
+                                       .orElseThrow(() -> new EntityException(ServiceErrorCode.USER_NOT_FOUND));
+    // 1. 연결끊기
+    unlinkManager.unlink(account.getProviderType(), String.valueOf(account.getProviderId()));
+    // 2. redis, httpsession 토큰 삭제
+    tokenService.removeRefreshToken(refreshToken);
+    // 3. Repository 에서 삭제 -> Soft Delete
+    account.updateDeleteDate();
+    accountRepository.save(account);
+  }
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/artist/persistence/Artist.java
+++ b/backend/src/main/java/com/pop/backend/domain/artist/persistence/Artist.java
@@ -22,11 +22,14 @@ public class Artist extends BaseEntity {
 
   private String description;
 
-  private Artist(String name, LocalDate birth, String profileImage, String description) {
+  private String token;
+
+  public Artist(String name, LocalDate birth, String profileImage, String description, String token) {
     this.name = name;
     this.birth = birth;
     this.profileImage = profileImage;
     this.description = description;
+    this.token = token;
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/domain/artist/persistence/ArtistContact.java
+++ b/backend/src/main/java/com/pop/backend/domain/artist/persistence/ArtistContact.java
@@ -23,15 +23,15 @@ public class ArtistContact extends BaseEntity {
 
   private String label;
 
-  private String value;
+  private String contactValue;
 
   @ManyToOne(fetch = FetchType.LAZY)
   private Artist artist;
 
-  private ArtistContact(ContactType type, String label, String value, Artist artist) {
+  private ArtistContact(ContactType type, String label, String contactValue, Artist artist) {
     this.type = type;
     this.label = label;
-    this.value = value;
+    this.contactValue = contactValue;
     this.artist = artist;
   }
 

--- a/backend/src/main/java/com/pop/backend/domain/artist/persistence/repository/ArtistRepository.java
+++ b/backend/src/main/java/com/pop/backend/domain/artist/persistence/repository/ArtistRepository.java
@@ -1,0 +1,8 @@
+package com.pop.backend.domain.artist.persistence.repository;
+
+import com.pop.backend.domain.artist.persistence.Artist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArtistRepository extends JpaRepository<Artist, Long>, QArtistRepository {
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/artist/persistence/repository/FollowArtistRepository.java
+++ b/backend/src/main/java/com/pop/backend/domain/artist/persistence/repository/FollowArtistRepository.java
@@ -1,0 +1,8 @@
+package com.pop.backend.domain.artist.persistence.repository;
+
+import com.pop.backend.domain.artist.persistence.FollowArtist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowArtistRepository extends JpaRepository<FollowArtist, Long> {
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/artist/persistence/repository/QArtistRepository.java
+++ b/backend/src/main/java/com/pop/backend/domain/artist/persistence/repository/QArtistRepository.java
@@ -1,0 +1,10 @@
+package com.pop.backend.domain.artist.persistence.repository;
+
+import com.pop.backend.domain.artist.persistence.Artist;
+import java.util.List;
+
+public interface QArtistRepository {
+
+  List<Artist> findFollowArtistListByAccountEmail(String email);
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/artist/persistence/repository/QArtistRepositoryImpl.java
+++ b/backend/src/main/java/com/pop/backend/domain/artist/persistence/repository/QArtistRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.pop.backend.domain.artist.persistence.repository;
+
+import static com.pop.backend.domain.account.persistence.QAccount.account;
+import static com.pop.backend.domain.artist.persistence.QArtist.artist;
+import static com.pop.backend.domain.artist.persistence.QFollowArtist.followArtist;
+
+import com.pop.backend.domain.account.persistence.Account;
+import com.pop.backend.domain.artist.persistence.Artist;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QArtistRepositoryImpl implements QArtistRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Artist> findFollowArtistListByAccountEmail(String email) {
+    Account findAccount = queryFactory.selectFrom(account).where(account.email.eq(email)).fetchOne();
+    return queryFactory.select(artist)
+                       .from(followArtist)
+                       .join(followArtist.artist, artist)
+                       .where(followArtist.account.eq(findAccount))
+                       .fetch();
+  }
+
+}

--- a/backend/src/main/java/com/pop/backend/domain/artwork/persistence/Artwork.java
+++ b/backend/src/main/java/com/pop/backend/domain/artwork/persistence/Artwork.java
@@ -25,14 +25,17 @@ public class Artwork extends BaseEntity {
 
   private LocalDate productionYear;
 
+  private String token;
+
   @ManyToOne(fetch = FetchType.LAZY)
   private Artist artist;
 
-  public Artwork(String name, String image, String description, LocalDate productionYear, Artist artist) {
+  public Artwork(String name, String image, String description, LocalDate productionYear, String token, Artist artist) {
     this.name = name;
     this.image = image;
     this.description = description;
     this.productionYear = productionYear;
+    this.token = token;
     this.artist = artist;
   }
 

--- a/backend/src/main/java/com/pop/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/pop/backend/global/config/RedisConfig.java
@@ -38,6 +38,7 @@ public class RedisConfig {
     redisTemplate.setValueSerializer(RedisSerializer.json());
     redisTemplate.setHashKeySerializer(RedisSerializer.string());
     redisTemplate.setHashValueSerializer(RedisSerializer.json());
+    redisTemplate.setEnableTransactionSupport(true);
     return redisTemplate;
   }
 }

--- a/backend/src/main/java/com/pop/backend/global/config/RestClientConfig.java
+++ b/backend/src/main/java/com/pop/backend/global/config/RestClientConfig.java
@@ -1,0 +1,16 @@
+package com.pop.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+  // 추후 timeout, ThreadPool 설정 예정
+  @Bean
+  public RestClient restClient() {
+    return RestClient.create();
+  }
+
+}

--- a/backend/src/main/java/com/pop/backend/global/exception/type/ServiceErrorCode.java
+++ b/backend/src/main/java/com/pop/backend/global/exception/type/ServiceErrorCode.java
@@ -16,7 +16,9 @@ public enum ServiceErrorCode {
   JSON_DESERIALIZE_ERROR(HttpStatus.CONFLICT, "JSON to Object 변환에 실패하였습니다."),
   INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 Content-Type 입니다."),
   BODY_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "Body 데이터 형식이 올바르지 않습니다."),
-  REDIS_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND, "Key와 일치하는 데이터가 존재하지 않습니다.");
+  REDIS_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND, "Key와 일치하는 데이터가 존재하지 않습니다."),
+  UNLINK_FAIL(HttpStatus.CONFLICT, "OAuth2 연결 끊기에 실패하였습니다."),
+  ACCOUNT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴한 계정입니다.");
 
   private final HttpStatus status;
   private final String errorMessage;

--- a/backend/src/main/java/com/pop/backend/global/exception/type/ServiceErrorCode.java
+++ b/backend/src/main/java/com/pop/backend/global/exception/type/ServiceErrorCode.java
@@ -15,7 +15,8 @@ public enum ServiceErrorCode {
   INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 변조되었습니다. 다시 로그인해주세요."),
   JSON_DESERIALIZE_ERROR(HttpStatus.CONFLICT, "JSON to Object 변환에 실패하였습니다."),
   INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 Content-Type 입니다."),
-  BODY_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "Body 데이터 형식이 올바르지 않습니다.");
+  BODY_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "Body 데이터 형식이 올바르지 않습니다."),
+  REDIS_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND, "Key와 일치하는 데이터가 존재하지 않습니다.");
 
   private final HttpStatus status;
   private final String errorMessage;

--- a/backend/src/main/java/com/pop/backend/global/redis/RefreshTokenClient.java
+++ b/backend/src/main/java/com/pop/backend/global/redis/RefreshTokenClient.java
@@ -8,9 +8,11 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component("RefreshTokenClient")
 @RequiredArgsConstructor
+@Transactional
 public class RefreshTokenClient implements RedisClient<RefreshToken> {
 
   private static final long TTL = 7L;

--- a/backend/src/main/java/com/pop/backend/global/redis/RefreshTokenClient.java
+++ b/backend/src/main/java/com/pop/backend/global/redis/RefreshTokenClient.java
@@ -1,5 +1,7 @@
 package com.pop.backend.global.redis;
 
+import com.pop.backend.global.exception.type.EntityException;
+import com.pop.backend.global.exception.type.ServiceErrorCode;
 import com.pop.backend.global.jwt.RefreshToken;
 import java.time.Duration;
 import java.util.Optional;
@@ -22,7 +24,8 @@ public class RefreshTokenClient implements RedisClient<RefreshToken> {
 
   @Override
   public RefreshToken findBy(String key) {
-    return Optional.ofNullable(redis.opsForValue().get(REFRESH_TOKEN_PREFIX + key)).orElseThrow();
+    RefreshToken value = redis.opsForValue().get(REFRESH_TOKEN_PREFIX + key);
+    return Optional.ofNullable(value).orElseThrow(() -> new EntityException(ServiceErrorCode.REDIS_VALUE_NOT_FOUND));
   }
 
   @Override

--- a/backend/src/main/java/com/pop/backend/global/security/auth/OAuth2UserAttributes.java
+++ b/backend/src/main/java/com/pop/backend/global/security/auth/OAuth2UserAttributes.java
@@ -12,7 +12,8 @@ public record OAuth2UserAttributes(
     ProviderType providerType,
     String email,
     String nickname,
-    String image
+    String image,
+    Long providerId
 ) {
 
   public static OAuth2UserAttributes of(OAuth2ProviderType providerType, Map<String, Object> attributes) {
@@ -33,6 +34,7 @@ public record OAuth2UserAttributes(
   @SuppressWarnings("unchecked")
   private static OAuth2UserAttributes fromKakao
       (OAuth2ProviderType providerType, Map<String, Object> attributes) {
+    Long providerId = (Long) attributes.get("id");
     Map<String, Object> kakaoAttributes = extractAttributes(providerType.ATTRIBUTES_FIELD, attributes);
     String email = (String) kakaoAttributes.get(providerType.EMAIL_FIELD);
 
@@ -42,7 +44,8 @@ public record OAuth2UserAttributes(
         ProviderType.find(providerType.name()),
         email,
         (String) kakaoAttributes.get(providerType.NICKNAME_FIELD),
-        (String) kakaoAttributes.get(providerType.IMAGE_FILED)
+        (String) kakaoAttributes.get(providerType.IMAGE_FILED),
+        providerId
     );
   }
 
@@ -54,7 +57,8 @@ public record OAuth2UserAttributes(
         ProviderType.find(providerType.name()),
         (String) naverAttributes.get(providerType.EMAIL_FIELD),
         (String) naverAttributes.get(providerType.NICKNAME_FIELD),
-        (String) naverAttributes.get(providerType.IMAGE_FILED)
+        (String) naverAttributes.get(providerType.IMAGE_FILED),
+        null
     );
   }
 
@@ -65,7 +69,8 @@ public record OAuth2UserAttributes(
         ProviderType.find(providerType.name()),
         (String) attributes.get(providerType.EMAIL_FIELD),
         (String) attributes.get(providerType.NICKNAME_FIELD),
-        (String) attributes.get(providerType.IMAGE_FILED)
+        (String) attributes.get(providerType.IMAGE_FILED),
+        null
     );
   }
 
@@ -74,13 +79,14 @@ public record OAuth2UserAttributes(
     return (Map<String, Object>) attributes.get(ATTRIBUTES_FIELD);
   }
 
-  public Account toMember(String password) {
+  public Account toAccount(String password) {
     return Account.builder()
                   .email(email)
                   .nickname(nickname)
                   .profileImage(image)
                   .password(password)
                   .providerType(providerType)
+                  .providerId(providerId)
                   .build();
   }
 

--- a/backend/src/main/java/com/pop/backend/global/security/config/SecurityBeanConfig.java
+++ b/backend/src/main/java/com/pop/backend/global/security/config/SecurityBeanConfig.java
@@ -8,8 +8,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.web.DefaultRedirectStrategy;
-import org.springframework.security.web.RedirectStrategy;
 
 @Configuration
 @RequiredArgsConstructor
@@ -20,11 +18,6 @@ public class SecurityBeanConfig {
   @Bean
   public BCryptPasswordEncoder bCryptPasswordEncoder() {
     return new BCryptPasswordEncoder();
-  }
-
-  @Bean
-  public RedirectStrategy redirectStrategy() {
-    return new DefaultRedirectStrategy();
   }
 
   @Bean

--- a/backend/src/main/java/com/pop/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pop/backend/global/security/config/SecurityConfig.java
@@ -63,7 +63,9 @@ public class SecurityConfig {
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
     http.authorizeHttpRequests(requestRegistry -> requestRegistry
-        .anyRequest().permitAll()); // API 설계시 수정 예정
+        .requestMatchers(HttpMethod.GET, "/api/accounts/signin/{provider}")
+        .permitAll()
+        .anyRequest().authenticated()); // API 설계시 수정 예정
 
     http.oauth2Login(oauth2LoginConfigurer -> oauth2LoginConfigurer
         .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig

--- a/backend/src/main/java/com/pop/backend/global/security/filter/JWTAuthenticationFilter.java
+++ b/backend/src/main/java/com/pop/backend/global/security/filter/JWTAuthenticationFilter.java
@@ -25,8 +25,7 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
   private final TokenService tokenService;
   private final PathMatcher pathMatcher = new AntPathMatcher();
   private final List<EndPoint> tokenFreeEndPoints = List.of(
-      new EndPoint("/api/accounts/signup", HttpMethod.POST),
-      new EndPoint("/api/accounts/signin", HttpMethod.POST)
+      new EndPoint("/api/accounts/signin/**", HttpMethod.GET)
   );
 
   @Override

--- a/backend/src/main/java/com/pop/backend/global/security/filter/SecurityExceptionHandleFilter.java
+++ b/backend/src/main/java/com/pop/backend/global/security/filter/SecurityExceptionHandleFilter.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -33,6 +34,7 @@ public class SecurityExceptionHandleFilter extends OncePerRequestFilter {
       HttpStatus status = e.getStatus();
       ErrorResponse errorResponse = new ServiceErrorResponse(e);
       response.setStatus(status.value());
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
       response.setCharacterEncoding(StandardCharsets.UTF_8.name());
       objectMapper.writeValue(response.getWriter(), errorResponse);
     }

--- a/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -21,7 +20,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
-  private final RedirectStrategy redirectStrategy;
   private final TokenService tokenService;
 
   @Value("${redirect-url.login-success}")
@@ -36,7 +34,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
       Authentication authentication) throws IOException, ServletException {
     GenerateToken tokens = generateToken(authentication);
     CookieManager.storeTokenInCookie(tokens, response);
-    redirectStrategy.sendRedirect(request, response, REDIRECT_URL);
+    response.sendRedirect(REDIRECT_URL);
   }
 
   private GenerateToken generateToken(Authentication authentication) {

--- a/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -7,12 +7,15 @@ import com.pop.backend.global.utils.CookieManager;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -35,6 +38,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     GenerateToken tokens = generateToken(authentication);
     CookieManager.storeTokenInCookie(tokens, response);
     response.sendRedirect(REDIRECT_URL);
+    clearSession(request);
   }
 
   private GenerateToken generateToken(Authentication authentication) {
@@ -45,6 +49,14 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                              .map(GrantedAuthority::getAuthority)
                              .collect(Collectors.joining(","));
     return tokenService.createJWT(email, authorities);
+  }
+
+  private void clearSession(HttpServletRequest request) {
+    SecurityContextHolder.clearContext();
+    HttpSession session = request.getSession(false);
+    if (Objects.nonNull(session)) {
+      session.invalidate();
+    }
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.RedirectStrategy;
@@ -20,9 +21,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
-  private final String REDIRECT_URL = "http://localhost/login-success";
   private final RedirectStrategy redirectStrategy;
   private final TokenService tokenService;
+
+  @Value("${redirect-url.login-success}")
+  private String REDIRECT_URL;
 
   /**
    * OAuth2 로그인 성공시 Authentication에 담긴 사용자 데이터를 기반으로 <br> AccessToken, RefreshToken 을 생성합니다. 두 데이터 모두 HttpOnly Cookie로

--- a/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LogoutSuccessHandler.java
+++ b/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LogoutSuccessHandler.java
@@ -7,15 +7,12 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2LogoutSuccessHandler implements LogoutSuccessHandler {
-
-  private final RedirectStrategy redirectStrategy;
 
   @Value("${redirect-url.logout}")
   private String REDIRECT_URL;
@@ -24,7 +21,7 @@ public class OAuth2LogoutSuccessHandler implements LogoutSuccessHandler {
   public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
       throws IOException, ServletException {
     response.getWriter().write("로그아웃이 완료되었습니다. 홈페이지로 이동합니다.");
-    redirectStrategy.sendRedirect(request, response, REDIRECT_URL);
+    response.sendRedirect(REDIRECT_URL);
   }
 
 }

--- a/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LogoutSuccessHandler.java
+++ b/backend/src/main/java/com/pop/backend/global/security/handler/OAuth2LogoutSuccessHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
@@ -14,8 +15,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OAuth2LogoutSuccessHandler implements LogoutSuccessHandler {
 
-  private final String REDIRECT_URL = "http://localhost/";
   private final RedirectStrategy redirectStrategy;
+
+  @Value("${redirect-url.logout}")
+  private String REDIRECT_URL;
 
   @Override
   public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)

--- a/backend/src/main/java/com/pop/backend/global/security/service/AuthorizationService.java
+++ b/backend/src/main/java/com/pop/backend/global/security/service/AuthorizationService.java
@@ -23,7 +23,7 @@ public class AuthorizationService {
   private Account save(OAuth2UserAttributes oAuth2UserAttributes) {
     String encodedPassword = passwordEncoder.encodedOAuth2Password(
         oAuth2UserAttributes.providerType(), oAuth2UserAttributes.email());
-    Account account = oAuth2UserAttributes.toMember(encodedPassword);
+    Account account = oAuth2UserAttributes.toAccount(encodedPassword);
     return memberRepository.save(account);
   }
 }

--- a/backend/src/main/java/com/pop/backend/global/security/service/KakaoOAuth2Unlink.java
+++ b/backend/src/main/java/com/pop/backend/global/security/service/KakaoOAuth2Unlink.java
@@ -1,0 +1,51 @@
+package com.pop.backend.global.security.service;
+
+import com.pop.backend.global.exception.type.SecurityException;
+import com.pop.backend.global.exception.type.ServiceErrorCode;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuth2Unlink implements OAuth2Unlink {
+
+  private static final String UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+  private final RestClient restClient;
+
+  @Value("${secret.kakao-admin}")
+  private String adminKey;
+
+  @Override
+  public void unlink(String value) {
+    final String authorization = "KakaoAK " + adminKey;
+
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("target_id_type", "user_id");
+    body.add("target_id", value);
+
+    Response response = restClient.post()
+                                  .uri(UNLINK_URL)
+                                  .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                  .header(HttpHeaders.AUTHORIZATION, authorization)
+                                  .body(body)
+                                  .retrieve()
+                                  .body(Response.class);
+
+    if (Objects.nonNull(response) && !Objects.equals(response.id(), value)) {
+      throw new SecurityException(ServiceErrorCode.BODY_DATA_NOT_FOUND);
+    }
+  }
+
+  private record Response(
+      String id
+  ) {
+
+  }
+}

--- a/backend/src/main/java/com/pop/backend/global/security/service/OAuth2Unlink.java
+++ b/backend/src/main/java/com/pop/backend/global/security/service/OAuth2Unlink.java
@@ -1,0 +1,7 @@
+package com.pop.backend.global.security.service;
+
+public interface OAuth2Unlink {
+
+  void unlink(String value);
+
+}

--- a/backend/src/main/java/com/pop/backend/global/security/service/OAuth2Unlink.java
+++ b/backend/src/main/java/com/pop/backend/global/security/service/OAuth2Unlink.java
@@ -2,6 +2,6 @@ package com.pop.backend.global.security.service;
 
 public interface OAuth2Unlink {
 
-  void unlink(String value);
+  boolean unlink(String value);
 
 }

--- a/backend/src/main/java/com/pop/backend/global/security/service/OAuth2UnlinkManager.java
+++ b/backend/src/main/java/com/pop/backend/global/security/service/OAuth2UnlinkManager.java
@@ -13,9 +13,9 @@ public class OAuth2UnlinkManager {
 
   private final KakaoOAuth2Unlink kakaoOAuth2Unlink;
 
-  public void unlink(ProviderType providerType, String value) {
-    if (Objects.requireNonNull(providerType) == ProviderType.KAKAO) {
-      kakaoOAuth2Unlink.unlink(value);
+  public boolean unlink(ProviderType providerType, String value) {
+    if (Objects.equals(providerType, ProviderType.KAKAO)) {
+      return kakaoOAuth2Unlink.unlink(value);
     } else {
       // OAuth2 Provider 확장 시 수정
       throw new SecurityException(ServiceErrorCode.PROVIDER_NOT_FOUND);

--- a/backend/src/main/java/com/pop/backend/global/security/service/OAuth2UnlinkManager.java
+++ b/backend/src/main/java/com/pop/backend/global/security/service/OAuth2UnlinkManager.java
@@ -1,0 +1,25 @@
+package com.pop.backend.global.security.service;
+
+import com.pop.backend.domain.account.persistence.type.ProviderType;
+import com.pop.backend.global.exception.type.SecurityException;
+import com.pop.backend.global.exception.type.ServiceErrorCode;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2UnlinkManager {
+
+  private final KakaoOAuth2Unlink kakaoOAuth2Unlink;
+
+  public void unlink(ProviderType providerType, String value) {
+    if (Objects.requireNonNull(providerType) == ProviderType.KAKAO) {
+      kakaoOAuth2Unlink.unlink(value);
+    } else {
+      // OAuth2 Provider 확장 시 수정
+      throw new SecurityException(ServiceErrorCode.PROVIDER_NOT_FOUND);
+    }
+  }
+
+}

--- a/backend/src/main/java/com/pop/backend/global/type/ArtistResponse.java
+++ b/backend/src/main/java/com/pop/backend/global/type/ArtistResponse.java
@@ -1,0 +1,15 @@
+package com.pop.backend.global.type;
+
+import com.pop.backend.domain.artist.persistence.Artist;
+
+public record ArtistResponse(
+    String name,
+    String image,
+    String token
+) {
+
+  public static ArtistResponse convert(Artist artist) {
+    return new ArtistResponse(artist.getName(), artist.getProfileImage(), artist.getToken());
+  }
+
+}

--- a/backend/src/main/java/com/pop/backend/global/type/BaseEntity.java
+++ b/backend/src/main/java/com/pop/backend/global/type/BaseEntity.java
@@ -7,7 +7,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -28,4 +30,9 @@ public abstract class BaseEntity {
   @LastModifiedDate
   @Column(nullable = false, columnDefinition = "datetime default now()")
   private LocalDateTime update_date;
+
+  @Setter(AccessLevel.PROTECTED)
+  @Column(columnDefinition = "datetime")
+  private LocalDateTime delete_date;
+
 }

--- a/backend/src/main/java/com/pop/backend/global/type/BaseEntity.java
+++ b/backend/src/main/java/com/pop/backend/global/type/BaseEntity.java
@@ -23,11 +23,11 @@ public abstract class BaseEntity {
   private Long id;
 
   @CreatedDate
-  @Column(updatable = false, nullable = false, columnDefinition = "datetime default now()")
+  @Column(updatable = false, nullable = false, columnDefinition = "datetime")
   private LocalDateTime create_date;
 
   @LastModifiedDate
-  @Column(nullable = false, columnDefinition = "datetime default now()")
+  @Column(nullable = false, columnDefinition = "datetime")
   private LocalDateTime update_date;
 
   @Column(columnDefinition = "datetime")

--- a/backend/src/main/java/com/pop/backend/global/type/BaseEntity.java
+++ b/backend/src/main/java/com/pop/backend/global/type/BaseEntity.java
@@ -7,9 +7,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
+import java.util.Objects;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -31,8 +30,15 @@ public abstract class BaseEntity {
   @Column(nullable = false, columnDefinition = "datetime default now()")
   private LocalDateTime update_date;
 
-  @Setter(AccessLevel.PROTECTED)
   @Column(columnDefinition = "datetime")
   private LocalDateTime delete_date;
+
+  public void updateDeleteDate() {
+    this.delete_date = LocalDateTime.now();
+  }
+
+  public boolean isDeleted() {
+    return Objects.nonNull(delete_date);
+  }
 
 }

--- a/backend/src/main/java/com/pop/backend/global/type/EntityToken.java
+++ b/backend/src/main/java/com/pop/backend/global/type/EntityToken.java
@@ -1,0 +1,31 @@
+package com.pop.backend.global.type;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+
+@RequiredArgsConstructor
+public enum EntityToken {
+
+  ARTIST("Artist_"),
+  ARTWORK("Artwork_");
+
+  private static final int TOKEN_LENGTH = 30;
+  private final String prefix;
+
+  public String randomCharacterWithPrefix() {
+    return this.prefix + randomCharacter(TOKEN_LENGTH - this.prefix.length());
+  }
+
+  public String extractToken(String token) {
+    return token.substring(this.prefix.length());
+  }
+
+  public String identifyToken(String tokenValue) {
+    return this.prefix + tokenValue;
+  }
+
+  private String randomCharacter(int length) {
+    return RandomStringUtils.randomAlphanumeric(length);
+  }
+
+}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         highlight_sql: true

--- a/backend/src/main/resources/application-production.yml
+++ b/backend/src/main/resources/application-production.yml
@@ -30,3 +30,7 @@ spring:
         registration:
           kakao:
             redirect-uri: ${KAKAO_REDIRECT_URL}
+
+redirect-url:
+  login-success: http://localhost/login-success
+  logout: http://localhost/ # 배포환경 구성시 수정 예정

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -34,3 +34,7 @@ spring:
         registration:
           kakao:
             redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+
+secret:
+  jwt: testJWTSecretKeytestJWTSecretKeytestJWTSecretKeytestJWTSecretKeytestJWTSecretKey
+  kakao-admin: testKakaoAdminKey

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
 
 secret:
   jwt: ${JWT_SECRET}
+  kakao-admin: ${KAKAO_ADMIN}
 
 logging:
   config: classpath:log4j2/log4j2.yml

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,3 +31,7 @@ secret:
 
 logging:
   config: classpath:log4j2/log4j2.yml
+
+redirect-url:
+  login-success: http://localhost/login-success
+  logout: http://localhost/

--- a/backend/src/main/resources/log4j2/log4j2.yml
+++ b/backend/src/main/resources/log4j2/log4j2.yml
@@ -25,17 +25,17 @@ Configutation:
     RollingFile:
       name: rolling-file-appender
       fileName: ${log-path}/rolling-file.log
-      filePattern: "${log-path}/archive/rollingFile.log.%d{yyyy-MM-dd_hhmm}_%i.gz"
+      filePattern: "${log-path}/archive/$${date:yyyy-MM}/rollingFile.log.%d{MM-dd-yyyy}_%i.gz"
       immediateFlush: "false"
       PatternLayout:
         charset: ${charset-UTF-8}
         pattern: ${file-layout-pattern}
       Policies:
         SizeBasedTriggeringPolicy:
-          size: "200KB"
+          size: "20MB"
         TimeBasedTriggeringPolicy:
           interval: "1"
-      DefaultRollOverStrategy:
+      DefaultRolloverStrategy:
         max: "10"
         fileIndex: "max"
 

--- a/backend/src/test/java/com/pop/backend/domain/account/AccountTest.java
+++ b/backend/src/test/java/com/pop/backend/domain/account/AccountTest.java
@@ -1,4 +1,4 @@
-package com.pop.backend.domain.user;
+package com.pop.backend.domain.account;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;

--- a/backend/src/test/java/com/pop/backend/domain/account/FollowArtistTest.java
+++ b/backend/src/test/java/com/pop/backend/domain/account/FollowArtistTest.java
@@ -1,0 +1,104 @@
+package com.pop.backend.domain.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.pop.backend.domain.account.persistence.Account;
+import com.pop.backend.domain.account.persistence.repository.AccountRepository;
+import com.pop.backend.domain.account.persistence.type.ProviderType;
+import com.pop.backend.domain.account.persistence.type.Role;
+import com.pop.backend.domain.artist.persistence.Artist;
+import com.pop.backend.domain.artist.persistence.FollowArtist;
+import com.pop.backend.domain.artist.persistence.repository.ArtistRepository;
+import com.pop.backend.domain.artist.persistence.repository.FollowArtistRepository;
+import com.pop.backend.global.TestConfig;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(TestConfig.class)
+@Transactional
+public class FollowArtistTest {
+
+  private final Logger logger = LoggerFactory.getLogger(FollowArtistTest.class);
+
+  private final String email = "test@test.com";
+  @Autowired
+  private ArtistRepository artistRepository;
+  @Autowired
+  private AccountRepository accountRepository;
+  @Autowired
+  private FollowArtistRepository followArtistRepository;
+
+  @BeforeEach
+  void init() {
+    logger.info("======================== Test Init Start ========================");
+    Account account = Account.builder().email(email)
+                             .role(Role.USER)
+                             .providerType(ProviderType.KAKAO)
+                             .build();
+    accountRepository.saveAndFlush(account);
+
+    Artist artist1 = Artist.builder()
+                           .name("artist1")
+                           .description("test description1")
+                           .token("token1")
+                           .build();
+    Artist artist2 = Artist.builder()
+                           .name("artist2")
+                           .description("test description2")
+                           .token("token2")
+                           .build();
+    Artist artist3 = Artist.builder()
+                           .name("artist3")
+                           .description("test description3")
+                           .token("token3")
+                           .build();
+    artistRepository.saveAllAndFlush(List.of(artist1, artist2, artist3));
+
+    FollowArtist followArtist1 = FollowArtist.builder().account(account).artist(artist1).build();
+    FollowArtist followArtist2 = FollowArtist.builder().account(account).artist(artist2).build();
+    FollowArtist followArtist3 = FollowArtist.builder().account(account).artist(artist3).build();
+    followArtistRepository.saveAllAndFlush(List.of(followArtist1, followArtist2, followArtist3));
+    logger.info("======================== Test Init end ========================");
+  }
+
+  @Test
+  @DisplayName("Follow Artist 조회 테스트")
+  void getFollowArtistListTest() {
+    List<Artist> artists = artistRepository.findFollowArtistListByAccountEmail(email);
+
+    assertThat(artists).extracting("name", "description")
+                       .containsExactly(
+                           tuple("artist1", "test description1"),
+                           tuple("artist2", "test description2"),
+                           tuple("artist3", "test description3")
+                       );
+  }
+
+  @Test
+  @DisplayName("Follow Artist 삭제 테스트")
+  void deleteFollowArtistsTest() {
+    //given
+    List<String> removeTokens = List.of("token1", "token3");
+
+    //when
+    accountRepository.removeFollowArtists(email, removeTokens);
+    List<Artist> artists = artistRepository.findFollowArtistListByAccountEmail(email);
+    //then
+    assertThat(artists).hasSize(1).extracting("name", "description")
+                       .containsExactly(
+                           tuple("artist2", "test description2")
+                       );
+  }
+}

--- a/backend/src/test/java/com/pop/backend/global/TestConfig.java
+++ b/backend/src/test/java/com/pop/backend/global/TestConfig.java
@@ -1,0 +1,22 @@
+package com.pop.backend.global;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class TestConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
이슈 X


## 🛠️ 작업 내용
### Login URL 변경
- Spring Security가 제공하는 OAuth2 로그인 엔드포인트인 `/oauth2/authorization/{provider_name}`을 클라이언트에 노출하는 것 보다는, 로그아웃, 회원탈퇴 등 Account 도메인 API와의 통일성을 유지하는 것이 적절하다 판단하였습니다.
- `/api/accounts/signin/{provider_name}` `GET` 요청시 `/oauth2/authorization/{provider_name}`으로 리디렉션하도록 구현하였습니다.
### 회원 탈퇴 기능 구현
- `/api/accounts/withdraw` `DELETE` 요청시 회원탈퇴를 진행합니다.
- email을 통해 조회한 Account.providerId와 카카오 어드민 Key를 사용해 OAuth2 연결끊기를 진행합니다.
- 연결끊기가 성공한다면 account의 delete_date를 갱신합니다.
- Redis에 저장된 RefreshToken을 삭제하고, Cookie에 저장한 Token을 삭제합니다.

### OAuth2 로그인시 HttpSession 클리어 로직 추가
- Redis를 HttpSession으로 사용하면서 OAuth2 로그인시 Session이 Redis에 생성되는 현상을 발견하였습니다.
- `/admin/**`을 제외한 모든 요청에 대해서는 SessionManagement를 Stateless로 설정해도, OAuth2 로그인 시에는 데이터를 저장하기 위해 HttpSession을 사용합니다.
- 이용자가 많아질수록 OAuth2 로그인 시에만 사용되는 HttpSession이 많아질 것이라 판단해, `OAuth2LoginSuccessHandler`에서 `HttpSession.invalidate()`를 수행하도록 수정하였습니다.

### Artist, Artwork에 Token 컬럼 추가
- Artist와 Artwork는 클라이언트에서 상세정보를 요청하는 서비스가 존재합니다.
- PK를 외부에 노출하는 것은 적절하지 않은 보안이라 판단하였습니다.
- `Artist_` , `Artwork_` 를 prefix로 하는 랜덤난수를 토큰으로 사용하도록 구현하였습니다.

### Follow Artist 조회, 삭제 기능 구현
- `/api/accounts/me/artists` `GET` 
  - Follow한 작가 목록을 조회합니다.
- `/api/accounts/me/artists` `DELETE`
  - 요청시 전달받은 token을 기반으로 FollowArtist 삭제를 진행합니다.  

## 💬 To Other
.
