### PR TITLE
✨ Feature: 작품 도메인 API 구현

### DIFF
--- a/backend/src/main/java/com/hiddenartist/backend/domain/artist/controller/ArtistController.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artist/controller/ArtistController.java
@@ -49,7 +49,7 @@ public class ArtistController {
   }
 
   @GetMapping("/{token}/signature-artworks")
-  public ArtistGetSignatureArtworkResponse getArtistFeatureArtworks(@PathVariable("token") String token) {
+  public ArtistGetSignatureArtworkResponse getArtistSignatureArtworks(@PathVariable("token") String token) {
     return artistService.getArtistSignatureArtworks(token);
   }
 

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/ArtworkController.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/ArtworkController.java
@@ -1,0 +1,24 @@
+package com.hiddenartist.backend.domain.artwork.controller;
+
+import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+import com.hiddenartist.backend.domain.artwork.service.ArtworkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/artworks")
+@RequiredArgsConstructor
+public class ArtworkController {
+
+  private final ArtworkService artworkService;
+
+
+  @GetMapping("/{token}")
+  public ArtworkGetDetailResponse getArtworkDetail(@PathVariable("token") String token) {
+    return artworkService.getArtworkDetail(token);
+  }
+
+}

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/ArtworkController.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/ArtworkController.java
@@ -4,8 +4,10 @@ import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDet
 import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetRecommendResponse;
 import com.hiddenartist.backend.domain.artwork.service.ArtworkService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +27,11 @@ public class ArtworkController {
   @GetMapping("/recommend")
   public ArtworkGetRecommendResponse getArtworkRecommend() {
     return artworkService.getArtworkRecommend();
+  }
+
+  @PostMapping("/{token}/pick")
+  public void savePickArtwork(@AuthenticationPrincipal String email, @PathVariable("token") String token) {
+    artworkService.savePickArtwork(email, token);
   }
 
 }

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/ArtworkController.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/ArtworkController.java
@@ -1,6 +1,7 @@
 package com.hiddenartist.backend.domain.artwork.controller;
 
 import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetRecommendResponse;
 import com.hiddenartist.backend.domain.artwork.service.ArtworkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +20,11 @@ public class ArtworkController {
   @GetMapping("/{token}")
   public ArtworkGetDetailResponse getArtworkDetail(@PathVariable("token") String token) {
     return artworkService.getArtworkDetail(token);
+  }
+
+  @GetMapping("/recommend")
+  public ArtworkGetRecommendResponse getArtworkRecommend() {
+    return artworkService.getArtworkRecommend();
   }
 
 }

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/response/ArtworkGetDetailResponse.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/response/ArtworkGetDetailResponse.java
@@ -3,6 +3,7 @@ package com.hiddenartist.backend.domain.artwork.controller.response;
 import com.hiddenartist.backend.domain.artist.persistence.Artist;
 import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
 import com.hiddenartist.backend.domain.genre.persistence.Genre;
+import com.hiddenartist.backend.global.type.EntityToken;
 import java.util.List;
 
 public record ArtworkGetDetailResponse(
@@ -50,7 +51,7 @@ public record ArtworkGetDetailResponse(
   ) {
 
     public static ArtistInfo create(Artist artist) {
-      return new ArtistInfo(artist.getName(), artist.getToken());
+      return new ArtistInfo(artist.getName(), EntityToken.ARTIST.extractToken(artist.getToken()));
     }
   }
 

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/response/ArtworkGetDetailResponse.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/response/ArtworkGetDetailResponse.java
@@ -1,0 +1,57 @@
+package com.hiddenartist.backend.domain.artwork.controller.response;
+
+import com.hiddenartist.backend.domain.artist.persistence.Artist;
+import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
+import com.hiddenartist.backend.domain.genre.persistence.Genre;
+import java.util.List;
+
+public record ArtworkGetDetailResponse(
+    String name,
+
+    String image,
+
+    List<String> genres,
+
+    Double width,
+
+    Double height,
+
+    Double depth,
+
+    List<ArtistInfo> artists,
+
+    String medium,
+
+    Integer productionYear,
+
+    String description
+) {
+
+  public static ArtworkGetDetailResponse create(Artwork artwork, List<Artist> artists, List<Genre> genres) {
+    List<String> genreNames = genres.stream().map(Genre::getName).toList();
+    List<ArtistInfo> artistInfos = artists.stream().map(ArtistInfo::create).toList();
+    return new ArtworkGetDetailResponse(
+        artwork.getName(),
+        artwork.getImage(),
+        genreNames,
+        artwork.getWidth(),
+        artwork.getHeight(),
+        artwork.getDepth(),
+        artistInfos,
+        artwork.getArtworkMedium().getTypeName(),
+        artwork.getProductionYear().getYear(),
+        artwork.getDescription()
+    );
+  }
+
+  public record ArtistInfo(
+      String name,
+      String token
+  ) {
+
+    public static ArtistInfo create(Artist artist) {
+      return new ArtistInfo(artist.getName(), artist.getToken());
+    }
+  }
+
+}

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/response/ArtworkGetRecommendResponse.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/controller/response/ArtworkGetRecommendResponse.java
@@ -1,0 +1,16 @@
+package com.hiddenartist.backend.domain.artwork.controller.response;
+
+import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
+import com.hiddenartist.backend.global.type.SimpleArtworkResponse;
+import java.util.List;
+
+public record ArtworkGetRecommendResponse(
+    List<SimpleArtworkResponse> artworks
+) {
+
+  public static ArtworkGetRecommendResponse create(List<Artwork> artworks) {
+    List<SimpleArtworkResponse> simpleArtworkResponses = artworks.stream().map(SimpleArtworkResponse::convert).toList();
+    return new ArtworkGetRecommendResponse(simpleArtworkResponses);
+  }
+
+}

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/Artwork.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/Artwork.java
@@ -2,6 +2,8 @@ package com.hiddenartist.backend.domain.artwork.persistence;
 
 import com.hiddenartist.backend.global.type.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,14 +24,28 @@ public class Artwork extends BaseEntity {
 
   private LocalDate productionYear;
 
+  private Double width;
+
+  private Double height;
+
+  private Double depth;
+
   private String token;
 
-  private Artwork(String name, String image, String description, LocalDate productionYear, String token) {
+  @ManyToOne(fetch = FetchType.LAZY)
+  private ArtworkMedium artworkMedium;
+
+  private Artwork(String name, String image, String description, LocalDate productionYear, Double width, Double height,
+      Double depth, String token, ArtworkMedium artworkMedium) {
     this.name = name;
     this.image = image;
     this.description = description;
     this.productionYear = productionYear;
+    this.width = width;
+    this.height = height;
+    this.depth = depth;
     this.token = token;
+    this.artworkMedium = artworkMedium;
   }
 
 }

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/ArtworkMedium.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/ArtworkMedium.java
@@ -1,0 +1,20 @@
+package com.hiddenartist.backend.domain.artwork.persistence;
+
+import com.hiddenartist.backend.global.type.BaseEntity;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtworkMedium extends BaseEntity {
+
+  private String typeName;
+
+}

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/ArtworkRepository.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/ArtworkRepository.java
@@ -3,6 +3,6 @@ package com.hiddenartist.backend.domain.artwork.persistence.repository;
 import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ArtworkRepository extends JpaRepository<Artwork, Long> {
+public interface ArtworkRepository extends JpaRepository<Artwork, Long>, CustomArtworkRepository {
 
 }

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/ArtworkRepository.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/ArtworkRepository.java
@@ -1,8 +1,11 @@
 package com.hiddenartist.backend.domain.artwork.persistence.repository;
 
 import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArtworkRepository extends JpaRepository<Artwork, Long>, CustomArtworkRepository {
+
+  Optional<Artwork> findByToken(String token);
 
 }

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepository.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepository.java
@@ -1,0 +1,9 @@
+package com.hiddenartist.backend.domain.artwork.persistence.repository;
+
+import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+
+public interface CustomArtworkRepository {
+
+  ArtworkGetDetailResponse findArtworkDetailByToken(String token);
+
+}

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepository.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepository.java
@@ -1,9 +1,13 @@
 package com.hiddenartist.backend.domain.artwork.persistence.repository;
 
 import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
+import java.util.List;
 
 public interface CustomArtworkRepository {
 
   ArtworkGetDetailResponse findArtworkDetailByToken(String token);
+
+  List<Artwork> findArtworkRecommend();
 
 }

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepositoryImpl.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.hiddenartist.backend.domain.artwork.persistence.repository;
+
+import static com.hiddenartist.backend.domain.artist.persistence.QArtist.artist;
+import static com.hiddenartist.backend.domain.artist.persistence.QArtistArtwork.artistArtwork;
+import static com.hiddenartist.backend.domain.artwork.persistence.QArtwork.artwork;
+import static com.hiddenartist.backend.domain.artwork.persistence.QArtworkMedium.artworkMedium;
+import static com.hiddenartist.backend.domain.genre.persistence.QArtworkGenre.artworkGenre;
+import static com.hiddenartist.backend.domain.genre.persistence.QGenre.genre;
+
+import com.hiddenartist.backend.domain.artist.persistence.Artist;
+import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
+import com.hiddenartist.backend.domain.genre.persistence.Genre;
+import com.hiddenartist.backend.global.exception.type.EntityException;
+import com.hiddenartist.backend.global.exception.type.ServiceErrorCode;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomArtworkRepositoryImpl implements CustomArtworkRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public ArtworkGetDetailResponse findArtworkDetailByToken(String token) {
+    // 토큰을 사용해서 Artwork 조회 -> ArtworkMedium fetch join
+    Artwork findArtwork = Optional.ofNullable(queryFactory.selectFrom(artwork)
+                                                          .leftJoin(artwork.artworkMedium, artworkMedium)
+                                                          .fetchJoin()
+                                                          .where(artwork.token.eq(token))
+                                                          .fetchOne())
+                                  .orElseThrow(() -> new EntityException(ServiceErrorCode.ARTWORK_NOT_FOUND));
+
+    // Artwork를 통해 Artist 조회 -> 이름, 토큰 추출
+    List<Artist> artists = queryFactory.select(artist)
+                                       .from(artistArtwork)
+                                       .join(artistArtwork.artist, artist)
+                                       .fetchJoin()
+                                       .where(artistArtwork.artwork.eq(findArtwork))
+                                       .orderBy(artist.name.asc())
+                                       .fetch();
+    // Artwork를 통해 ArtworkGenre 조회 -> List<Genre> 추출
+    List<Genre> genres = queryFactory.select(genre)
+                                     .from(artworkGenre)
+                                     .join(artworkGenre.genre, genre)
+                                     .fetchJoin()
+                                     .where(artworkGenre.artwork.eq(findArtwork))
+                                     .orderBy(genre.name.asc())
+                                     .fetch();
+    return ArtworkGetDetailResponse.create(findArtwork, artists, genres);
+  }
+}

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepositoryImpl.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepositoryImpl.java
@@ -27,7 +27,6 @@ public class CustomArtworkRepositoryImpl implements CustomArtworkRepository {
 
   @Override
   public ArtworkGetDetailResponse findArtworkDetailByToken(String token) {
-    // 토큰을 사용해서 Artwork 조회 -> ArtworkMedium fetch join
     Artwork findArtwork = Optional.ofNullable(queryFactory.selectFrom(artwork)
                                                           .leftJoin(artwork.artworkMedium, artworkMedium)
                                                           .fetchJoin()
@@ -35,19 +34,16 @@ public class CustomArtworkRepositoryImpl implements CustomArtworkRepository {
                                                           .fetchOne())
                                   .orElseThrow(() -> new EntityException(ServiceErrorCode.ARTWORK_NOT_FOUND));
 
-    // Artwork를 통해 Artist 조회 -> 이름, 토큰 추출
     List<Artist> artists = queryFactory.select(artist)
                                        .from(artistArtwork)
                                        .join(artistArtwork.artist, artist)
-                                       .fetchJoin()
                                        .where(artistArtwork.artwork.eq(findArtwork))
                                        .orderBy(artist.name.asc())
                                        .fetch();
-    // Artwork를 통해 ArtworkGenre 조회 -> List<Genre> 추출
+
     List<Genre> genres = queryFactory.select(genre)
                                      .from(artworkGenre)
                                      .join(artworkGenre.genre, genre)
-                                     .fetchJoin()
                                      .where(artworkGenre.artwork.eq(findArtwork))
                                      .orderBy(genre.name.asc())
                                      .fetch();

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepositoryImpl.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/CustomArtworkRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
 import com.hiddenartist.backend.domain.genre.persistence.Genre;
 import com.hiddenartist.backend.global.exception.type.EntityException;
 import com.hiddenartist.backend.global.exception.type.ServiceErrorCode;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -49,4 +50,18 @@ public class CustomArtworkRepositoryImpl implements CustomArtworkRepository {
                                      .fetch();
     return ArtworkGetDetailResponse.create(findArtwork, artists, genres);
   }
+
+  @Override
+  public List<Artwork> findArtworkRecommend() {
+    Long totalCount = queryFactory.select(artwork.count()).from(artwork).fetchOne();
+    if (totalCount < 3) {
+      return queryFactory.selectFrom(artwork).fetch();
+    }
+
+    return queryFactory.selectFrom(artwork)
+                       .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
+                       .limit(3)
+                       .fetch();
+  }
+
 }

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/PickArtworkRepository.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/persistence/repository/PickArtworkRepository.java
@@ -1,0 +1,8 @@
+package com.hiddenartist.backend.domain.artwork.persistence.repository;
+
+import com.hiddenartist.backend.domain.artwork.persistence.PickArtwork;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PickArtworkRepository extends JpaRepository<PickArtwork, Long> {
+
+}

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/service/ArtworkService.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/service/ArtworkService.java
@@ -1,8 +1,11 @@
 package com.hiddenartist.backend.domain.artwork.service;
 
 import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetRecommendResponse;
+import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
 import com.hiddenartist.backend.domain.artwork.persistence.repository.ArtworkRepository;
 import com.hiddenartist.backend.global.type.EntityToken;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,4 +22,11 @@ public class ArtworkService {
     String token = EntityToken.ARTWORK.identifyToken(tokenValue);
     return artworkRepository.findArtworkDetailByToken(token);
   }
+
+  @Transactional(readOnly = true)
+  public ArtworkGetRecommendResponse getArtworkRecommend() {
+    List<Artwork> artworkRecommend = artworkRepository.findArtworkRecommend();
+    return ArtworkGetRecommendResponse.create(artworkRecommend);
+  }
+
 }

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/service/ArtworkService.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/service/ArtworkService.java
@@ -1,0 +1,22 @@
+package com.hiddenartist.backend.domain.artwork.service;
+
+import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+import com.hiddenartist.backend.domain.artwork.persistence.repository.ArtworkRepository;
+import com.hiddenartist.backend.global.type.EntityToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ArtworkService {
+
+  private final ArtworkRepository artworkRepository;
+
+
+  @Transactional(readOnly = true)
+  public ArtworkGetDetailResponse getArtworkDetail(String tokenValue) {
+    String token = EntityToken.ARTWORK.identifyToken(tokenValue);
+    return artworkRepository.findArtworkDetailByToken(token);
+  }
+}

--- a/backend/src/main/java/com/hiddenartist/backend/domain/artwork/service/ArtworkService.java
+++ b/backend/src/main/java/com/hiddenartist/backend/domain/artwork/service/ArtworkService.java
@@ -1,9 +1,15 @@
 package com.hiddenartist.backend.domain.artwork.service;
 
+import com.hiddenartist.backend.domain.account.persistence.Account;
+import com.hiddenartist.backend.domain.account.persistence.repository.AccountRepository;
 import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
 import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetRecommendResponse;
 import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
+import com.hiddenartist.backend.domain.artwork.persistence.PickArtwork;
 import com.hiddenartist.backend.domain.artwork.persistence.repository.ArtworkRepository;
+import com.hiddenartist.backend.domain.artwork.persistence.repository.PickArtworkRepository;
+import com.hiddenartist.backend.global.exception.type.EntityException;
+import com.hiddenartist.backend.global.exception.type.ServiceErrorCode;
 import com.hiddenartist.backend.global.type.EntityToken;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ArtworkService {
 
   private final ArtworkRepository artworkRepository;
-
+  private final AccountRepository accountRepository;
+  private final PickArtworkRepository pickArtworkRepository;
 
   @Transactional(readOnly = true)
   public ArtworkGetDetailResponse getArtworkDetail(String tokenValue) {
@@ -27,6 +34,17 @@ public class ArtworkService {
   public ArtworkGetRecommendResponse getArtworkRecommend() {
     List<Artwork> artworkRecommend = artworkRepository.findArtworkRecommend();
     return ArtworkGetRecommendResponse.create(artworkRecommend);
+  }
+
+  @Transactional
+  public void savePickArtwork(String email, String tokenValue) {
+    String token = EntityToken.ARTWORK.identifyToken(tokenValue);
+    Account account = accountRepository.findByEmail(email)
+                                       .orElseThrow(() -> new EntityException(ServiceErrorCode.USER_NOT_FOUND));
+    Artwork artwork = artworkRepository.findByToken(token)
+                                       .orElseThrow(() -> new EntityException(ServiceErrorCode.ARTWORK_NOT_FOUND));
+    PickArtwork pickArtwork = PickArtwork.builder().account(account).artwork(artwork).build();
+    pickArtworkRepository.save(pickArtwork);
   }
 
 }

--- a/backend/src/main/java/com/hiddenartist/backend/global/db/DummyDataInitializer.java
+++ b/backend/src/main/java/com/hiddenartist/backend/global/db/DummyDataInitializer.java
@@ -9,10 +9,12 @@ import com.hiddenartist.backend.domain.artist.persistence.Artist;
 import com.hiddenartist.backend.domain.artist.persistence.ArtistContact;
 import com.hiddenartist.backend.domain.artist.persistence.type.ContactType;
 import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
-import com.hiddenartist.backend.domain.genre.persistence.Genre;
+import com.hiddenartist.backend.domain.artwork.persistence.ArtworkMedium;
 import com.hiddenartist.backend.global.type.EntityToken;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -21,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -38,7 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DummyDataInitializer {
 
   private final JdbcTemplate jdbcTemplate;
-  private final long ARTIST_ID = 1L;
+  private final long ID = 1L;
   private final List<Long> LIST = List.of(1L, 2L, 3L);
 
   @Transactional
@@ -50,73 +51,83 @@ public class DummyDataInitializer {
   }
 
   private void insertDummyData() {
-    saveDummyAccounts();
-    saveDummyArtists();
-    saveDummyArtistContacts();
-    saveDummyGenres();
-    saveDummyArtistGenre();
-    saveDummyFollowArtist();
-    saveDummyArtworks();
-    saveDummySignatureArtworks();
-    saveDummyArtistArtwork();
+    saveAccounts(20);
+    saveGenre();
+    saveArtists(500);
+    saveArtistGenre();
+    saveFollowArtists(20);
+    saveArtworks(20);
+    saveArtworkGenre();
+    saveSignatureArtworks();
   }
 
-  private void saveDummyAccounts() {
-    List<Account> accounts = IntStream.rangeClosed(1, 20).mapToObj(this::createDummyAccount).toList();
-    String sql = "insert into account (email,nickname,role,provider_type) values (?,?,?,?)";
+  private void saveAccounts(int size) {
+    List<Account> accounts = IntStream.rangeClosed(1, size).mapToObj(this::createAccount).toList();
+    String sql = "insert into account (id,email,nickname,role,provider_type) values (?,?,?,?,?)";
     jdbcTemplate.batchUpdate(sql, accounts, accounts.size(), (ps, account) -> {
-      ps.setString(1, account.getEmail());
-      ps.setString(2, account.getNickname());
-      ps.setString(3, account.getRole().name());
-      ps.setString(4, account.getProviderType().name());
+      ps.setLong(1, accounts.indexOf(account) + 1);
+      ps.setString(2, account.getEmail());
+      ps.setString(3, account.getNickname());
+      ps.setString(4, account.getRole().name());
+      ps.setString(5, account.getProviderType().name());
     });
   }
 
-  private void saveDummyArtists() {
-    List<Artist> artists = IntStream.rangeClosed(1, 500).mapToObj(this::createDummyArtist).toList();
-    String sql = "insert into artist (name,token,birth,summary,description,profile_image) values (?,?,?,?,?,?)";
+
+  private void saveArtists(int size) {
+    saveArtist(size);
+    saveArtistContact();
+  }
+
+  private void saveArtist(int size) {
+    List<Artist> artists = IntStream.rangeClosed(1, size).mapToObj(this::createArtist).toList();
+    String sql = "insert into artist (id,name,profile_image,token,summary,description,birth,create_date) values(?,?,?,?,?,?,?,?)";
+    LocalDateTime now = LocalDateTime.now();
     jdbcTemplate.batchUpdate(sql, artists, artists.size(), (ps, artist) -> {
-      ps.setString(1, artist.getName());
-      ps.setString(2, artist.getToken());
-      ps.setDate(3, Date.valueOf(artist.getBirth()));
-      ps.setString(4, artist.getSummary());
-      ps.setString(5, artist.getDescription());
-      ps.setString(6, artist.getProfileImage());
+      ps.setLong(1, artists.indexOf(artist) + 1);
+      ps.setString(2, artist.getName());
+      ps.setString(3, artist.getProfileImage());
+      ps.setString(4, artist.getToken());
+      ps.setString(5, artist.getSummary());
+      ps.setString(6, artist.getDescription());
+      ps.setDate(7, Date.valueOf(artist.getBirth()));
+      ps.setTimestamp(8, Timestamp.valueOf(now.plusDays(artists.indexOf(artist))));
     });
   }
 
-  private void saveDummyArtistContacts() {
+  private void saveArtistContact() {
     List<ArtistContact> artistContacts = createArtistContacts();
-    String sql = "insert into artist_contact (type,label,contact_value,artist_id) values (?,?,?,?)";
-    jdbcTemplate.batchUpdate(sql, artistContacts, artistContacts.size(), (ps, contact) -> {
-      ps.setString(1, contact.getType().name());
-      ps.setString(2, contact.getLabel());
-      ps.setString(3, contact.getContactValue());
-      ps.setLong(4, ARTIST_ID);
+    String sql = "insert into artist_contact (type,label,contact_value,artist_id) values(?,?,?,?)";
+    jdbcTemplate.batchUpdate(sql, artistContacts, artistContacts.size(), (ps, artistContact) -> {
+      ps.setString(1, artistContact.getType().name());
+      ps.setString(2, artistContact.getLabel());
+      ps.setString(3, artistContact.getContactValue());
+      ps.setLong(4, ID);
     });
   }
 
-  private void saveDummyGenres() {
-    List<Genre> genres = Stream.of("현대미술", "조소", "추상화").map(Genre::new).toList();
-    String sql = "insert into genre (name) values (?)";
+  private void saveGenre() {
+    String sql = "insert into genre (id,name) values (?,?)";
+    List<String> genres = List.of("현대미술", "조소", "추상화");
     jdbcTemplate.batchUpdate(sql, genres, genres.size(), (ps, genre) -> {
-      ps.setString(1, genre.getName());
+      ps.setLong(1, genres.indexOf(genre) + 1);
+      ps.setString(2, genre);
     });
   }
 
-  private void saveDummyArtistGenre() {
-    String sql = "insert into artist_genre (artist_id,genre_id) values (?,?)";
-    jdbcTemplate.batchUpdate(sql, LIST, LIST.size(), (ps, genreId) -> {
-      ps.setLong(1, ARTIST_ID);
-      ps.setLong(2, genreId);
+  private void saveArtistGenre() {
+    String sql = "insert into artist_genre (artist_id,genre_id) values(?,?)";
+    jdbcTemplate.batchUpdate(sql, LIST, LIST.size(), (ps, id) -> {
+      ps.setLong(1, ID);
+      ps.setLong(2, id);
     });
   }
 
-  private void saveDummyFollowArtist() {
-    List<Long> accountIds = LongStream.rangeClosed(1, 20).boxed().toList();
+  private void saveFollowArtists(int accountSize) {
+    List<Long> accountIds = LongStream.rangeClosed(1L, accountSize).boxed().toList();
     String sql = "insert into follow_artist (account_id,artist_id) values (?,?)";
     Random random = new Random();
-    jdbcTemplate.batchUpdate(sql, accountIds, accountIds.size(), (ps, accountId) -> {
+    jdbcTemplate.batchUpdate(sql, accountIds, accountSize, (ps, accountId) -> {
       Set<Long> artistIds = random.longs(1, 501)
                                   .distinct()
                                   .limit(50)
@@ -129,42 +140,69 @@ public class DummyDataInitializer {
     });
   }
 
-  private void saveDummyArtworks() {
-    List<Artwork> artworks = IntStream.rangeClosed(1, 20).mapToObj(this::createDummyArtwork).toList();
-    String sql = "insert into artwork (name,image,description,token) values (?,?,?,?)";
+  private void saveArtworks(int size) {
+    saveArtworkMediums();
+    saveArtwork(size);
+  }
+
+  private void saveArtwork(int size) {
+    size = Math.max(size, 3);
+    List<Artwork> artworks = IntStream.rangeClosed(1, size)
+                                      .mapToObj(this::createArtwork)
+                                      .toList();
+    String sql = "insert into artwork (id,name,image,description,token,width,height,production_year,artwork_medium_id) values (?,?,?,?,?,?,?,?,?)";
     jdbcTemplate.batchUpdate(sql, artworks, artworks.size(), (ps, artwork) -> {
-      ps.setString(1, artwork.getName());
-      ps.setString(2, artwork.getImage());
-      ps.setString(3, artwork.getDescription());
-      ps.setString(4, artwork.getToken());
+      int artworkId = artworks.indexOf(artwork) + 1;
+      ps.setLong(1, artworkId);
+      ps.setString(2, artwork.getName());
+      ps.setString(3, artwork.getImage());
+      ps.setString(4, artwork.getDescription());
+      ps.setString(5, artwork.getToken());
+      ps.setDouble(6, artwork.getWidth());
+      ps.setDouble(7, artwork.getHeight());
+      ps.setDate(8, Date.valueOf(artwork.getProductionYear()));
+      ps.setLong(9, ((artworkId) % 5) + 1);
     });
-  }
 
-  private void saveDummyArtistArtwork() {
-    String sql = "select id from artwork where 1 <= id and id <=10";
-    List<Long> artworkIds = jdbcTemplate.queryForList(sql, Long.class);
     sql = "insert into artist_artwork (artist_id,artwork_id) values (?,?)";
-    jdbcTemplate.batchUpdate(sql, artworkIds, artworkIds.size(), (ps, artworkId) -> {
-      ps.setLong(1, ARTIST_ID);
-      ps.setLong(2, artworkId);
+    jdbcTemplate.batchUpdate(sql, artworks, artworks.size(), (ps, artwork) -> {
+      ps.setLong(1, 1L);
+      ps.setLong(2, artworks.indexOf(artwork) + 1);
     });
   }
 
-  private void saveDummySignatureArtworks() {
-    String sql = "insert into signature_artwork (artwork_id,display_order) values (?,?) ";
+  private void saveArtworkGenre() {
+    String sql = "insert into artwork_genre (artwork_id,genre_id) values(?,?)";
     jdbcTemplate.batchUpdate(sql, LIST, LIST.size(), (ps, id) -> {
-      ps.setLong(1, id);
-      ps.setByte(2, (byte) (id - 1));
+      ps.setLong(1, ID);
+      ps.setLong(2, id);
     });
   }
 
-  private Account createDummyAccount(int count) {
-    String email = "test" + count + "@test.com";
-    String nickname = "test account " + count;
-    return Account.builder().providerType(ProviderType.KAKAO).role(Role.USER).email(email).nickname(nickname).build();
+  private void saveArtworkMediums() {
+    ArtworkMedium artworkMedium1 = ArtworkMedium.builder().typeName("수채화").build();
+    ArtworkMedium artworkMedium2 = ArtworkMedium.builder().typeName("유화").build();
+    ArtworkMedium artworkMedium3 = ArtworkMedium.builder().typeName("디지털 아트").build();
+    ArtworkMedium artworkMedium4 = ArtworkMedium.builder().typeName("3D 아트").build();
+    ArtworkMedium artworkMedium5 = ArtworkMedium.builder().typeName("POP 아트").build();
+    List<ArtworkMedium> artworkMediums = List.of(artworkMedium1, artworkMedium2, artworkMedium3, artworkMedium4,
+        artworkMedium5);
+    String sql = "insert into artwork_medium (id,type_name) values (?,?)";
+    jdbcTemplate.batchUpdate(sql, artworkMediums, artworkMediums.size(), (ps, artworkMedium) -> {
+      ps.setLong(1, artworkMediums.indexOf(artworkMedium) + 1);
+      ps.setString(2, artworkMedium.getTypeName());
+    });
   }
 
-  private Artist createDummyArtist(int count) {
+  private void saveSignatureArtworks() {
+    String sql = "insert into signature_artwork ( artwork_id,display_order) values(?,?)";
+    jdbcTemplate.batchUpdate(sql, LIST, LIST.size(), (ps, artworkId) -> {
+      ps.setLong(1, artworkId);
+      ps.setByte(2, (byte) LIST.indexOf(artworkId));
+    });
+  }
+
+  private Artist createArtist(int count) {
     int year = 1990 + (count % 20);
     int month = (count % 12) + 1;
     int days = (count % 30) + 1;
@@ -174,7 +212,7 @@ public class DummyDataInitializer {
                  .birth(LocalDate.of(year, month, days))
                  .summary("test summary " + count)
                  .description("test description " + count)
-                 .token(EntityToken.ARTIST.randomCharacterWithPrefix())
+                 .token(EntityToken.ARTIST.createEntityToken())
                  .build();
   }
 
@@ -207,12 +245,24 @@ public class DummyDataInitializer {
     return List.of(contact1, contact2, contact3, contact4, contact5);
   }
 
-  private Artwork createDummyArtwork(int count) {
+  private Artwork createArtwork(int count) {
     return Artwork.builder()
                   .name("Artwork" + count)
                   .image("Test Artwork Image" + count)
                   .description("Test Artwork Description" + count)
-                  .token(EntityToken.ARTWORK.randomCharacterWithPrefix())
+                  .productionYear(LocalDate.of(2000 + count, 1, 1))
+                  .width(20.1 + count)
+                  .height(30.5 + count)
+                  .token(EntityToken.ARTWORK.identifyToken(String.valueOf(count)))
+                  .build();
+  }
+
+  private Account createAccount(int count) {
+    return Account.builder()
+                  .email("test" + count + "@test.com")
+                  .nickname("test user" + count)
+                  .role(Role.USER)
+                  .providerType(ProviderType.KAKAO)
                   .build();
   }
 

--- a/backend/src/main/java/com/hiddenartist/backend/global/exception/type/ServiceErrorCode.java
+++ b/backend/src/main/java/com/hiddenartist/backend/global/exception/type/ServiceErrorCode.java
@@ -10,6 +10,7 @@ public enum ServiceErrorCode {
 
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "Email에 부합하는 회원이 존재하지 않습니다."),
   ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "Artist를 찾을 수 없습니다."),
+  ARTWORK_NOT_FOUND(HttpStatus.NOT_FOUND, "Artwork를 찾을 수 없습니다."),
   PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "OAuth2 Provider를 찾을 수 없습니다."),
   TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰을 찾을 수 없습니다. 로그인해주세요."),
   INVALID_REFRESH_TOKEN(HttpStatus.CONFLICT, "토큰이 일치하지 않습니다. 다시 로그인해주세요."),

--- a/backend/src/main/java/com/hiddenartist/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hiddenartist/backend/global/security/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
       EndPoint.create("/api/artists/{token}", HttpMethod.GET),
       EndPoint.create("/api/artists/popular", HttpMethod.GET),
       EndPoint.create("/api/artists/{token}/signature-artworks", HttpMethod.GET),
-      EndPoint.create("/api/artworks/{token}", HttpMethod.GET)
+      EndPoint.create("/api/artworks/{token}", HttpMethod.GET),
+      EndPoint.create("/api/artworks/recommend", HttpMethod.GET)
   );
 
   private final CustomOAuth2UserService oAuth2UserService;

--- a/backend/src/main/java/com/hiddenartist/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hiddenartist/backend/global/security/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
       EndPoint.create("/api/artists", HttpMethod.GET),
       EndPoint.create("/api/artists/{token}", HttpMethod.GET),
       EndPoint.create("/api/artists/popular", HttpMethod.GET),
-      EndPoint.create("/api/artists/{token}/signature-artworks", HttpMethod.GET)
+      EndPoint.create("/api/artists/{token}/signature-artworks", HttpMethod.GET),
+      EndPoint.create("/api/artworks/{token}", HttpMethod.GET)
   );
 
   private final CustomOAuth2UserService oAuth2UserService;

--- a/backend/src/main/java/com/hiddenartist/backend/global/security/filter/JWTAuthenticationFilter.java
+++ b/backend/src/main/java/com/hiddenartist/backend/global/security/filter/JWTAuthenticationFilter.java
@@ -30,7 +30,8 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
       EndPoint.create("/api/artists", HttpMethod.GET),
       EndPoint.create("/api/artists/**", HttpMethod.GET),
       EndPoint.create("/api/artists/popular", HttpMethod.GET),
-      EndPoint.create("/api/artists/{token}/signature-artworks", HttpMethod.GET)
+      EndPoint.create("/api/artists/{token}/signature-artworks", HttpMethod.GET),
+      EndPoint.create("/api/artworks/**", HttpMethod.GET)
   );
 
   @Override

--- a/backend/src/main/java/com/hiddenartist/backend/global/security/filter/JWTAuthenticationFilter.java
+++ b/backend/src/main/java/com/hiddenartist/backend/global/security/filter/JWTAuthenticationFilter.java
@@ -31,7 +31,8 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
       EndPoint.create("/api/artists/**", HttpMethod.GET),
       EndPoint.create("/api/artists/popular", HttpMethod.GET),
       EndPoint.create("/api/artists/{token}/signature-artworks", HttpMethod.GET),
-      EndPoint.create("/api/artworks/**", HttpMethod.GET)
+      EndPoint.create("/api/artworks/**", HttpMethod.GET),
+      EndPoint.create("/api/artworks/recommend", HttpMethod.GET)
   );
 
   @Override

--- a/backend/src/main/java/com/hiddenartist/backend/global/type/EntityToken.java
+++ b/backend/src/main/java/com/hiddenartist/backend/global/type/EntityToken.java
@@ -12,7 +12,7 @@ public enum EntityToken {
   private static final int TOKEN_LENGTH = 30;
   private final String prefix;
 
-  public String randomCharacterWithPrefix() {
+  public String createEntityToken() {
     return this.prefix + randomCharacter(TOKEN_LENGTH - this.prefix.length());
   }
 

--- a/backend/src/test/java/com/hiddenartist/backend/domain/artwork/persistence/repository/ArtworkRepositoryTest.java
+++ b/backend/src/test/java/com/hiddenartist/backend/domain/artwork/persistence/repository/ArtworkRepositoryTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
 import com.hiddenartist.backend.global.config.CustomDataJpaTest;
 import com.hiddenartist.backend.global.config.TestDataInitializer;
 import com.hiddenartist.backend.global.type.EntityToken;
+import java.util.HashSet;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +31,7 @@ class ArtworkRepositoryTest {
     initializer.saveArtworks(1);
 
     String token = EntityToken.ARTWORK.identifyToken("1");
+
     //when
     ArtworkGetDetailResponse artworkDetailByToken = artworkRepository.findArtworkDetailByToken(token);
 
@@ -42,6 +46,21 @@ class ArtworkRepositoryTest {
                                               .containsExactly(tuple
                                                   ("artist1", "1")
                                               );
+  }
+
+  @Test
+  @DisplayName("추천 작품 3개 조회")
+  void findArtworkRecommendTest() {
+    //given
+    initializer.saveArtists(1);
+    initializer.saveArtworks(50);
+
+    //when
+    List<Artwork> result = artworkRepository.findArtworkRecommend();
+    HashSet<Artwork> uniqueResult = new HashSet<>(result);
+
+    //then
+    assertThat(result).isNotNull().hasSize(uniqueResult.size());
   }
 
 }

--- a/backend/src/test/java/com/hiddenartist/backend/domain/artwork/persistence/repository/ArtworkRepositoryTest.java
+++ b/backend/src/test/java/com/hiddenartist/backend/domain/artwork/persistence/repository/ArtworkRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.hiddenartist.backend.domain.artwork.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.hiddenartist.backend.domain.artwork.controller.response.ArtworkGetDetailResponse;
+import com.hiddenartist.backend.global.config.CustomDataJpaTest;
+import com.hiddenartist.backend.global.config.TestDataInitializer;
+import com.hiddenartist.backend.global.type.EntityToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@CustomDataJpaTest
+class ArtworkRepositoryTest {
+
+  @Autowired
+  private TestDataInitializer initializer;
+
+  @Autowired
+  private ArtworkRepository artworkRepository;
+
+  @Test
+  @DisplayName("Token 입력시 Artwork Detail 반환")
+  void findArtworkDetailByTokenTest() {
+    //given
+    initializer.saveArtists(1);
+    initializer.saveArtworks(1);
+
+    String token = EntityToken.ARTWORK.identifyToken("1");
+    //when
+    ArtworkGetDetailResponse artworkDetailByToken = artworkRepository.findArtworkDetailByToken(token);
+
+    //then
+    assertThat(artworkDetailByToken).isNotNull()
+                                    .extracting("name", "image", "width", "height", "medium", "productionYear",
+                                        "description")
+                                    .containsExactly("Artwork1", "Test Artwork Image1", 21.1, 31.5, "유화", 2001,
+                                        "Test Artwork Description1");
+    assertThat(artworkDetailByToken.artists()).hasSize(1)
+                                              .extracting("name", "token")
+                                              .containsExactly(tuple
+                                                  ("artist1", "1")
+                                              );
+  }
+
+}

--- a/backend/src/test/java/com/hiddenartist/backend/global/DataInitializerTest.java
+++ b/backend/src/test/java/com/hiddenartist/backend/global/DataInitializerTest.java
@@ -5,9 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hiddenartist.backend.domain.account.persistence.repository.AccountRepository;
 import com.hiddenartist.backend.domain.artist.persistence.Artist;
 import com.hiddenartist.backend.domain.artist.persistence.repository.ArtistRepository;
+import com.hiddenartist.backend.domain.artwork.persistence.Artwork;
 import com.hiddenartist.backend.domain.artwork.persistence.repository.ArtworkRepository;
 import com.hiddenartist.backend.global.config.CustomDataJpaTest;
 import com.hiddenartist.backend.global.config.TestDataInitializer;
+import com.hiddenartist.backend.global.type.EntityToken;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,22 @@ public class DataInitializerTest {
     assertThat(artistCount).isEqualTo(100);
     assertThat(artworkCount).isEqualTo(20);
     assertThat(followArtists).hasSize(20);
+  }
+
+  @Test
+  @DisplayName("Artwork 초기화 테스트")
+  void initializerTest2() {
+    //given
+    initializer.saveArtists(1);
+    initializer.saveArtworks(20);
+
+    //when
+    Artwork artwork = artworkRepository.findById(1L).get();
+    //then
+    assertThat(artwork).isNotNull()
+                       .extracting("name", "image", "token")
+                       .containsExactly("Artwork1", "Test Artwork Image1", EntityToken.ARTWORK.identifyToken("1"));
+    assertThat(artwork.getArtworkMedium()).extracting("typeName").isEqualTo("유화");
   }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#18 


## 🛠️ 작업 내용
### 작품 상세정보 조회 기능 구현
`/api/artworks/{token}` `GET`
- PathVariable의 token 값을 파싱해 해당 token으로 작품의 상세정보를 조회합니다.
- 3개의 쿼리를 통해 `ArtworkGetDetailResponse`를 생성합니다.
  - token을 통해 `Artwork` Entity를 조회하는 쿼리
  - 조회한 `Artwork` 를 통해 `Artist` Entity, `Genre` Entity를 각각 조회하는 쿼리 
- 작품의 매체(팝아트, 유화)등을 나타내는 `ArtworkMedium` Entity는 Artwort 조회시 **fetch join**으로 조회하도록 구성하였습니다.

### 작품 추천 기능 구현
`/api/artworks/recommend` `GET`
- 랜덤 작품 3개를 추천해주는 API입니다.
- 기능 구현에 대한 논의가 마무리 되지않아, 등록된 모든 `Artwork` Entity 를 MySQL의 `RAND()` 함수를 사용해 정렬한 후, 3개만 조회하도록 구현하였습니다.
- 추후 기능 정의가 완료된다면, 재설계및 리팩토링 진행 예정입니다.

### 작품 Pick 기능 구현
`/api/artworks/{token}/pick` `POST`
- 마음에 드는 작품을 Pick 하는 기능입니다.
  - Artist Follow API와 유사한 로직을 수행합니다.
- JWT 인증을 통해 추출한 `Principal` 인 email과 PathVariable로 추출한 token을 사용해 `PickArtwork` Entity를 DB에 저장합니다.

### 테이블 리팩토링
- `Artwork` 테이블 설계 시 작품매체와 작품의 사이즈에 대한 컬럼을 정의하지 않았습니다.
- 해당 이슈를 발견하고 작품 매체를 정의하는 `ArtworkMedium` 테이블을 생성하고, `Artwork` 테이블에는 width, height, depth 컬럼을 추가하였습니다.

### DataInitializer 수정
- `Artwork`테이블 구조 수정, `ArtworkMedium` 테이블 생성으로 인해 DataInitializer의 메서드를 수정하였습니다.

## 💬 To Other
.