### PR TITLE
⚒️ Fix: Gradle build Cache 설정 수정

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop'}}
 
       - name: Grant execute permission to Gradlew
         run: chmod +x ./gradlew

--- a/.github/workflows/backend-push.yml
+++ b/.github/workflows/backend-push.yml
@@ -2,7 +2,7 @@ name: POP Backend Push Workflow
 
 on:
   push:
-    branches: [ 'feature/**','chore/**','fix/**','refactor/**' ]
+    branches: [ 'develop', 'feature/**','chore/**','fix/**','refactor/**' ]
     paths:
       - 'backend/**'
       - '.github/**'


### PR DESCRIPTION
## #️⃣ 연관된 이슈
이슈 x


## 🛠️ 작업 내용
### Gradle Cache 설정 수정
- Gradle Cache가 진행되는 default branch가 `main` 임을 [gradle/actions/setup-gradle 공식문서](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md)를 통해 확인하였습니다.
- 현재는 `develop` 브랜치에 작업내용이 merge 되고 있어, `develop` 브랜치도 gradle cache가 write 되도록 수정하였습니다.

### Workflow Trigger branch 수정
- `develop` 브랜치가 push, pull-request 모두 trigger 되도록 수정하였습니다.

## 💬 To Other
`develop` 브랜치의 workflow 작업 이후 다른 workflow의 작업속도를 체크하겠습니다.
